### PR TITLE
Change v1 to v2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,8 +81,8 @@ APP_PREVIEW_CLIENT=
 ##### client [itkdev/os2display-client] #####
 APP_API_ENDPOINT="https://demo.os2display.dk"
 APP_API_PATH="https://demo.os2display.dk"
-APP_API_AUTHENTICATION_ENDPOINT="https://demo.os2display.dk/v1/authentication/screen"
-APP_API_AUTHENTICATION_REFRESH_ENDPOINT="https://demo.os2display.dk/v1/authentication/token/refresh"
+APP_API_AUTHENTICATION_ENDPOINT="https://demo.os2display.dk/v2/authentication/screen"
+APP_API_AUTHENTICATION_REFRESH_ENDPOINT="https://demo.os2display.dk/v2/authentication/token/refresh"
 APP_DATA_PULL_INTERVAL=90000
 APP_SCHEDULING_INTERVAL=60000
 APP_DEBUG=false


### PR DESCRIPTION
It believe this should be v2 instead of v1 as the README af the display-api-service suggests here: https://github.com/os2display/display-api-service/blob/develop/README.md#jwt-auth